### PR TITLE
Add optional low pass audio filter

### DIFF
--- a/src/burner/libretro/libretro_core_options.h
+++ b/src/burner/libretro/libretro_core_options.h
@@ -78,7 +78,46 @@ struct retro_core_option_definition option_defs_us[] = {
          { "disabled", NULL },
          { NULL, NULL },
       },
-      "enabled"
+      "disabled"
+   },
+   {
+      "fba2012cps1_lowpass_filter",
+      "Audio Filter",
+      "Enables a low pass audio filter to soften the 'harsh' sound of some arcade games.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "fba2012cps1_lowpass_range",
+      "Audio Filter Level (%)",
+      "Specifies the cut-off frequency of the low pass audio filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
+      {
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { "35", NULL },
+         { "40", NULL },
+         { "45", NULL },
+         { "50", NULL },
+         { "55", NULL },
+         { "60", NULL },
+         { "65", NULL },
+         { "70", NULL },
+         { "75", NULL },
+         { "80", NULL },
+         { "85", NULL },
+         { "90", NULL },
+         { "95", NULL },
+         { NULL, NULL },
+      },
+      "60"
    },
    {
       "fba2012cps1_frameskip",


### PR DESCRIPTION
Arcade content has a tendency to sound harsh/abrasive, in part due to the prevalence of low quality audio samples. This PR seeks to mitigate the issue by adding an optional (and fast) low pass audio filter. This is enabled via a new `Audio Filter` core option, and the filter 'strength' can be set via `Audio Filter Level (%)`.

This makes many games sound far more pleasant, and has a negligible performance impact.