### PR TITLE
Add aspect ratio correction + display rotation improvements

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -278,7 +278,7 @@ else ifeq ($(platform), gcw0)
    fpic := -fPIC
    SHARED := -shared -Wl,--gc-sections -Wl,-no-undefined -Wl,--version-script=$(LIBRETRO_DIR)/link.T
    LDFLAGS += $(PTHREAD_FLAGS)
-   CFLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR
+   CFLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR -DDINGUX
    CFLAGS += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
    CFLAGS +=  -fomit-frame-pointer -ffunction-sections -fdata-sections
    CXXFLAGS += -std=gnu++11 $(CFLAGS)

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -956,7 +956,7 @@ static bool fba_init(unsigned driver, const char *game_zip_name)
          rotate_buf_margin = 0;
 #endif
          g_fba_rotate_buf = (uint16_t*)calloc(1,
-               rotate_buf_width * rotate_buf_height * sizeof(uint16_t));
+               (uint32_t)rotate_buf_width * (uint32_t)rotate_buf_height * sizeof(uint16_t));
       }
    }
 

--- a/src/burner/libretro/libretro_core_options.h
+++ b/src/burner/libretro/libretro_core_options.h
@@ -81,6 +81,28 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "fba2012cps1_aspect",
+      "Core-Provided Aspect Ratio",
+      "Selects the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
+      {
+         { "DAR", NULL },
+         { "PAR", NULL },
+         { NULL, NULL },
+      },
+      "DAR"
+   },
+   {
+      "fba2012cps1_auto_rotate",
+      "Rotate Vertically Aligned Games (Restart)",
+      "Automatically rotate the display when running vertically aligned games. When disabled, D-Pad input will be rotated to match on-screen directions.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "fba2012cps1_lowpass_filter",
       "Audio Filter",
       "Enables a low pass audio filter to soften the 'harsh' sound of some arcade games.",


### PR DESCRIPTION
This PR makes the following improvements to the core:

- A new `Core-Provided Aspect Ratio` option has been added. This can be set to `DAR` or `PAR`. When `DAR` is selected, the core outputs content at a ratio of 4:3 (or 3:4 for vertical games). Previously, the core always used `PAR` (resulting in stretched graphics)

- At present, the core uses gfx driver hardware-based rotation to display vertical games with the correct orientation. For platforms without hardware rotation support, this is clearly inadequate. This PR adds a new software-based fallback, so rotation now works on all devices. (It is quite slow, however...)

- A new `Rotate Vertically Aligned Games (Restart)` option has been added. When enabled (by default), vertical games are always rotated. When disabled, they are displayed in landscape orientation - *and* d-pad inputs are automatically rotated to match the on-screen directions. This makes vertical games highly playable on devices that are too slow for software-based rotation

- A memory leak has been fixed (input wasn't being de-initialised correctly...)

- An out of bounds array write has been fixed

- The video buffer has been halved in size by dropping 4 bpp 'support' (this was pointless, since the core only uses 2 bpp). Note that the video buffer still has to be oversized, because some games end up writing beyond the regular width x height space...